### PR TITLE
fix: Resolve conflicting IPv6 and IPv4 addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Alternatively, the user may pass `"once"`, `"always"` or even `"error"`.
 
 Finally, note that some operations issue two warnings, e.g. `c1-c2` issues a warning for computing `-c2` and a warning for computing `c1 + (-c2)`.
 
-### Advanced usgae
+### Advanced usage
 
 The basic usage in the example above can be improved upon by explicitly randomizing as late as possible, i.e. by
 only randomizing non-fresh ciphertexts directly before they are communicated using the `randomize()` method.
@@ -259,7 +259,7 @@ stat_sec_shamir = (
 
 def setup_local_pool(server_port: int, others: List[Tuple[str, int]]) -> Pool:
     pool = Pool()
-    pool.add_http_server(server_port, "localhost")
+    pool.add_http_server(server_port)
     for client_ip, client_port in others:
         pool.add_http_client(
             f"client_{client_ip}_{client_port}", client_ip, client_port

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ PARTIES = 4  # number of parties that will be involved in the protocol, you can 
 
 def setup_local_pool(server_port: int, ports: List[int]) -> Pool:
     pool = Pool()
-    pool.add_http_server(server_port, "127.0.0.1")
+    pool.add_http_server(server_port)
     for client_port in (port for port in ports if port != server_port):
         pool.add_http_client(f"client{client_port}", "127.0.0.1", client_port)
     return pool

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ def setup_local_pool(server_port: int, ports: List[int]) -> Pool:
     pool = Pool()
     pool.add_http_server(server_port)
     for client_port in (port for port in ports if port != server_port):
-        pool.add_http_client(f"client{client_port}", "127.0.0.1", client_port)
+        pool.add_http_client(f"client{client_port}", "localhost", client_port)
     return pool
 
 

--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ PARTIES = 4  # number of parties that will be involved in the protocol, you can 
 
 def setup_local_pool(server_port: int, ports: List[int]) -> Pool:
     pool = Pool()
-    pool.add_http_server(server_port, "localhost")
+    pool.add_http_server(server_port, "127.0.0.1")
     for client_port in (port for port in ports if port != server_port):
-        pool.add_http_client(f"client{client_port}", "localhost", client_port)
+        pool.add_http_client(f"client{client_port}", "127.0.0.1", client_port)
     return pool
 
 


### PR DESCRIPTION
I tested with Fedora 36 and localhost is translated in ::: rather than 127.0.0.1. It might be better to change it with 127.0.0.1